### PR TITLE
Add catalog filtering, sorting, and pagination controls

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import BookCard from "@/components/BookCard";
+import CatalogClient from "@/components/CatalogClient";
 import { fetchBooks } from "@/lib/booksApi";
 import type { Book } from "@/types/book";
 
@@ -20,8 +20,8 @@ export default async function CatalogPage() {
           Explore Our Digital Catalog
         </h1>
         <p className="max-w-2xl text-slate-400">
-          Find your next neon-soaked adventure among cyberspace legends,
-          glitchpunk thrillers, and synthwave sagas.
+          Find your next read on the Neo-Net. Tune your filters to surface
+          fresh transmissions from across the digital stacks.
         </p>
       </header>
       <div className="rounded-2xl border border-cyan-500/20 bg-slate-950/60 p-6 shadow-[0_0_35px_rgba(56,189,248,0.12)]">
@@ -34,11 +34,7 @@ export default async function CatalogPage() {
             Loading data from the Neo-Net archives...
           </p>
         ) : (
-          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {books.map((book) => (
-              <BookCard key={book.id} book={book} />
-            ))}
-          </div>
+          <CatalogClient initialBooks={books} />
         )}
       </div>
     </section>

--- a/src/components/CatalogClient.tsx
+++ b/src/components/CatalogClient.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useEffect, useMemo } from "react";
+
+import { useBookStore } from "@/store/useBookStore";
+import type { Book } from "@/types/book";
+
+import BookGrid from "./BookGrid";
+import CatalogFilters from "./CatalogFilters";
+
+type CatalogClientProps = {
+  initialBooks: Book[];
+};
+
+export default function CatalogClient({ initialBooks }: CatalogClientProps) {
+  const books = useBookStore((state) => state.books);
+  const filters = useBookStore((state) => state.filters);
+  const pagination = useBookStore((state) => state.pagination);
+  const setBooks = useBookStore((state) => state.setBooks);
+  const setPage = useBookStore((state) => state.setPage);
+
+  useEffect(() => {
+    setBooks(initialBooks);
+  }, [initialBooks, setBooks]);
+
+  const filteredBooks = useMemo(() => {
+    const searchTerm = filters.search.trim().toLowerCase();
+
+    return books.filter((book) => {
+      const matchesSearch =
+        !searchTerm ||
+        [book.title, book.author]
+          .filter(Boolean)
+          .some((value) => value.toLowerCase().includes(searchTerm));
+
+      const bookCategory = book.category ?? "Fiction";
+      const matchesCategory =
+        filters.category === "All" || bookCategory === filters.category;
+
+      return matchesSearch && matchesCategory;
+    });
+  }, [books, filters.category, filters.search]);
+
+  const sortedBooks = useMemo(() => {
+    const sorted = [...filteredBooks];
+
+    switch (filters.sort) {
+      case "author": {
+        sorted.sort((a, b) => a.author.localeCompare(b.author));
+        break;
+      }
+      case "popularity": {
+        sorted.sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
+        break;
+      }
+      case "publicationDate":
+      default: {
+        sorted.sort((a, b) => (b.year ?? 0) - (a.year ?? 0));
+        break;
+      }
+    }
+
+    return sorted;
+  }, [filteredBooks, filters.sort]);
+
+  const totalPages = Math.max(
+    1,
+    Math.ceil(sortedBooks.length / pagination.pageSize),
+  );
+
+  useEffect(() => {
+    if (pagination.currentPage > totalPages) {
+      setPage(totalPages);
+    }
+  }, [pagination.currentPage, setPage, totalPages]);
+
+  const currentPage = Math.min(pagination.currentPage, totalPages);
+  const startIndex = (currentPage - 1) * pagination.pageSize;
+  const paginatedBooks = sortedBooks.slice(
+    startIndex,
+    startIndex + pagination.pageSize,
+  );
+
+  const showingFrom = sortedBooks.length ? startIndex + 1 : 0;
+  const showingTo = Math.min(
+    sortedBooks.length,
+    startIndex + pagination.pageSize,
+  );
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) {
+      return;
+    }
+
+    setPage(page);
+  };
+
+  return (
+    <div className="space-y-6">
+      <CatalogFilters />
+      <BookGrid
+        books={paginatedBooks}
+        emptyState={<p>No transmissions detected. Try adjusting your filters.</p>}
+      />
+      <div className="flex flex-col gap-4 rounded-xl border border-cyan-500/10 bg-slate-950/40 p-4 text-sm text-slate-400 md:flex-row md:items-center md:justify-between">
+        <span>
+          {sortedBooks.length
+            ? `Showing ${showingFrom}-${showingTo} of ${sortedBooks.length} results`
+            : "No results found"}
+        </span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handlePageChange(currentPage - 1)}
+            className="rounded-full border border-cyan-500/30 px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition hover:border-cyan-400/60 hover:text-cyan-200 disabled:cursor-not-allowed disabled:border-slate-700 disabled:text-slate-600"
+            disabled={currentPage === 1}
+          >
+            Prev
+          </button>
+          {Array.from({ length: totalPages }, (_, index) => {
+            const pageNumber = index + 1;
+            const isActive = pageNumber === currentPage;
+
+            return (
+              <button
+                key={pageNumber}
+                type="button"
+                onClick={() => handlePageChange(pageNumber)}
+                className={`rounded-full border px-3 py-2 text-sm transition ${
+                  isActive
+                    ? "border-cyan-400/80 bg-cyan-500/20 text-cyan-200 shadow-[0_0_15px_rgba(56,189,248,0.35)]"
+                    : "border-cyan-500/20 text-slate-400 hover:border-cyan-400/60 hover:text-cyan-200"
+                }`}
+              >
+                {pageNumber}
+              </button>
+            );
+          })}
+          <button
+            type="button"
+            onClick={() => handlePageChange(currentPage + 1)}
+            className="rounded-full border border-cyan-500/30 px-3 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-300 transition hover:border-cyan-400/60 hover:text-cyan-200 disabled:cursor-not-allowed disabled:border-slate-700 disabled:text-slate-600"
+            disabled={currentPage === totalPages}
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CatalogFilters.tsx
+++ b/src/components/CatalogFilters.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { ChangeEvent } from "react";
+
+import { useBookStore } from "@/store/useBookStore";
+
+const CATEGORY_OPTIONS = [
+  { label: "All Categories", value: "All" as const },
+  { label: "Fiction", value: "Fiction" as const },
+  { label: "Science", value: "Science" as const },
+  { label: "History", value: "History" as const },
+];
+
+const SORT_OPTIONS = [
+  { label: "Author", value: "author" as const },
+  { label: "Popularity", value: "popularity" as const },
+  { label: "Publication Date", value: "publicationDate" as const },
+];
+
+export default function CatalogFilters() {
+  const filters = useBookStore((state) => state.filters);
+  const updateFilters = useBookStore((state) => state.updateFilters);
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    updateFilters({ search: event.target.value });
+  };
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    updateFilters({ category: event.target.value as (typeof CATEGORY_OPTIONS)[number]["value"] });
+  };
+
+  const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    updateFilters({ sort: event.target.value as (typeof SORT_OPTIONS)[number]["value"] });
+  };
+
+  return (
+    <div className="space-y-4">
+      <input
+        className="cyber-input"
+        placeholder="Search by title or author..."
+        value={filters.search}
+        onChange={handleSearchChange}
+        type="search"
+        aria-label="Search the catalog by title or author"
+      />
+      <div className="grid gap-4 md:grid-cols-2">
+        <select
+          className="cyber-select"
+          value={filters.category}
+          onChange={handleCategoryChange}
+          aria-label="Filter catalog by category"
+        >
+          {CATEGORY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        <select
+          className="cyber-select"
+          value={filters.sort}
+          onChange={handleSortChange}
+          aria-label="Sort catalog"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/booksApi.ts
+++ b/src/lib/booksApi.ts
@@ -24,7 +24,7 @@ function buildCoverUrl(doc: {
 
 export async function fetchBooks(query: string = DEFAULT_QUERY): Promise<Book[]> {
   const response = await fetch(
-    `${OPEN_LIBRARY_SEARCH_ENDPOINT}?q=${encodeURIComponent(query)}&limit=20`,
+    `${OPEN_LIBRARY_SEARCH_ENDPOINT}?q=${encodeURIComponent(query)}&limit=40`,
     {
       headers: {
         "Content-Type": "application/json",
@@ -46,12 +46,14 @@ export async function fetchBooks(query: string = DEFAULT_QUERY): Promise<Book[]>
       cover_i?: number;
       cover_edition_key?: string;
       first_publish_year?: number;
+      edition_count?: number;
+      subject?: string[];
     }>;
   };
 
   const docs = data.docs ?? [];
 
-  return docs.slice(0, 12).map((doc, index) => ({
+  return docs.slice(0, 40).map((doc, index) => ({
     id: doc.key.replace("/works/", ""),
     title: doc.title,
     author: doc.author_name?.[0] ?? "Unknown Author",
@@ -59,5 +61,35 @@ export async function fetchBooks(query: string = DEFAULT_QUERY): Promise<Book[]>
     year: doc.first_publish_year,
     format: "Digital", // Placeholder until richer metadata is surfaced.
     status: STATUS_COLORS[index % STATUS_COLORS.length],
+    popularity: doc.edition_count ?? 0,
+    category: inferCategory(doc.subject),
   }));
+}
+
+type CatalogCategory = NonNullable<Book["category"]>;
+
+const CATEGORY_KEYWORDS: Record<CatalogCategory, string[]> = {
+  Fiction: ["fiction", "novel", "fantasy", "literature", "story", "drama"],
+  Science: ["science", "scientific", "physics", "biology", "chemistry", "technology"],
+  History: ["history", "historical", "biography", "civilization", "war"],
+};
+
+function inferCategory(subjects: string[] | undefined): CatalogCategory {
+  if (!subjects?.length) {
+    return "Fiction";
+  }
+
+  const normalizedSubjects = subjects.map((subject) => subject.toLowerCase());
+
+  for (const [category, keywords] of Object.entries(CATEGORY_KEYWORDS)) {
+    if (
+      normalizedSubjects.some((subject) =>
+        keywords.some((keyword) => subject.includes(keyword)),
+      )
+    ) {
+      return category as CatalogCategory;
+    }
+  }
+
+  return "Fiction";
 }

--- a/src/lib/booksApi.ts
+++ b/src/lib/booksApi.ts
@@ -34,16 +34,15 @@ export async function fetchBooks({
   limit = DEFAULT_LIMIT,
   signal,
 }: FetchBooksParams = {}): Promise<Book[]> {
-  const requestInit: RequestInit & { next?: { revalidate: number } } = {
-    headers: {
-      "Content-Type": "application/json",
-    },
-    // Cache responses so catalog loads fast while still refreshing periodically.
-    next: { revalidate: 3600 },
-  };
+  const requestInit: RequestInit & { next?: { revalidate: number } } = {};
 
   if (signal) {
     requestInit.signal = signal;
+  }
+
+  if (typeof window === "undefined") {
+    // Cache responses so catalog loads fast while still refreshing periodically on the server.
+    requestInit.next = { revalidate: 3600 };
   }
 
   const response = await fetch(

--- a/src/store/useBookStore.ts
+++ b/src/store/useBookStore.ts
@@ -3,43 +3,77 @@
 import { create } from "zustand";
 import type { Book } from "@/types/book";
 
+type CatalogCategory = "All" | "Fiction" | "Science" | "History";
+type SortOption = "author" | "popularity" | "publicationDate";
+
 type BookFilters = {
   search: string;
-  genres: string[];
-  sort: "recent" | "title" | "author";
+  category: CatalogCategory;
+  sort: SortOption;
+};
+
+type PaginationState = {
+  currentPage: number;
+  pageSize: number;
 };
 
 type BookState = {
   books: Book[];
   isLoading: boolean;
   filters: BookFilters;
+  pagination: PaginationState;
   setBooks: (books: Book[]) => void;
   setIsLoading: (isLoading: boolean) => void;
   updateFilters: (filters: Partial<BookFilters>) => void;
+  setPage: (page: number) => void;
   reset: () => void;
 };
 
 const initialFilters: BookFilters = {
   search: "",
-  genres: [],
-  sort: "recent",
+  category: "All",
+  sort: "publicationDate",
+};
+
+const initialPagination: PaginationState = {
+  currentPage: 1,
+  pageSize: 12,
 };
 
 const initialState = {
   books: [] as Book[],
   isLoading: false,
   filters: initialFilters,
+  pagination: initialPagination,
 };
 
 export const useBookStore = create<BookState>((set) => ({
   ...initialState,
-  setBooks: (books) => set({ books }),
+  setBooks: (books) =>
+    set((state) => ({
+      books,
+      pagination: {
+        ...state.pagination,
+        currentPage: 1,
+      },
+    })),
   setIsLoading: (isLoading) => set({ isLoading }),
   updateFilters: (filters) =>
     set((state) => ({
       filters: {
         ...state.filters,
         ...filters,
+      },
+      pagination: {
+        ...state.pagination,
+        currentPage: 1,
+      },
+    })),
+  setPage: (page) =>
+    set((state) => ({
+      pagination: {
+        ...state.pagination,
+        currentPage: page,
       },
     })),
   reset: () => set(initialState),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -73,4 +73,34 @@ body {
   backdrop-filter: blur(12px);
 }
 
+.cyber-input,
+.cyber-select {
+  @apply w-full rounded-xl border border-cyan-500/30 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 transition duration-200 placeholder:text-slate-500 focus:border-cyan-400 focus:ring-2 focus:ring-cyan-500/40;
+  box-shadow: 0 0 25px rgba(56, 189, 248, 0.12);
+  backdrop-filter: blur(16px);
+}
+
+.cyber-input:focus,
+.cyber-select:focus {
+  box-shadow: 0 0 35px rgba(56, 189, 248, 0.25);
+}
+
+.cyber-select {
+  appearance: none;
+  padding-right: 3rem;
+  background-image: linear-gradient(
+      135deg,
+      rgba(56, 189, 248, 0.25),
+      rgba(14, 165, 233, 0.15)
+    ),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%2300f5ff' d='M5 6 0 0h10z'/%3E%3C/svg%3E");
+  background-position: left top, right 1rem center;
+  background-repeat: no-repeat;
+  background-size: cover, 0.75rem 0.5rem;
+}
+
+.cyber-select option {
+  color: #020617;
+}
+
 /* TODO: Add keyframe animations for glitch effects and holographic pulses. */

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -8,6 +8,8 @@ export interface Book {
   format?: string;
   tags?: string[];
   status?: "available" | "borrowed";
+  category?: "Fiction" | "Science" | "History";
+  popularity?: number;
 }
 
 // TODO: Extend with availability, ISBNs, reading progress, and cyberpunk metadata.


### PR DESCRIPTION
## Summary
- add a client-side catalog view that reads from a Zustand store with filtering, sorting, and pagination
- introduce cyber-themed search and select controls for catalog filtering and update global styles
- enrich fetched books with category and popularity metadata to support new catalog features

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e493e5de0c8330a2efef99778da381